### PR TITLE
fix: Исправлена серия критических ошибок в Celery-воркере

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -49,11 +49,6 @@ class Settings(BaseSettings):
     # Logging
     log_level: str = Field(default="INFO")
 
-    DATABASE_URL: PostgresDsn
-    VK_ACCESS_TOKEN: str
-    VK_API_VERSION: str = "5.131"
-    REDIS_URL: str = "redis://redis:6379/0"
-
     def get_cors_origins(self) -> list[str]:
         """Получить список CORS origins"""
         return [origin.strip() for origin in self.cors_origins.split(",")]

--- a/backend/app/services/parser_service.py
+++ b/backend/app/services/parser_service.py
@@ -87,7 +87,7 @@ class ParserService:
                     stats.new_comments += comment_stats["new"]
                     stats.keyword_matches += comment_stats["matches"]
 
-                post.last_parsed_at = datetime.now(timezone.utc)
+                post.last_parsed_at = datetime.utcnow()
                 stats.posts_processed += 1
                 if progress_callback:
                     progress = (i + 1) / total_posts
@@ -126,7 +126,7 @@ class ParserService:
             post.reposts_count = post_data.get("reposts", {}).get("count", 0)
             post.comments_count = post_data.get("comments", {}).get("count", 0)
             post.views_count = post_data.get("views", {}).get("count", 0)
-            post.updated_at = datetime.fromtimestamp(post_data["date"], tz=timezone.utc)
+            post.updated_at = datetime.utcnow()
             return post
 
         new_post = VKPost(
@@ -137,8 +137,7 @@ class ParserService:
             reposts_count=post_data.get("reposts", {}).get("count", 0),
             comments_count=post_data.get("comments", {}).get("count", 0),
             views_count=post_data.get("views", {}).get("count", 0),
-            published_at=datetime.fromtimestamp(post_data["date"], tz=timezone.utc),
-            updated_at=datetime.fromtimestamp(post_data["date"], tz=timezone.utc),
+            published_at=post_data["date"].replace(tzinfo=None),
         )
         self.db.add(new_post)
         await self.db.flush()
@@ -205,7 +204,7 @@ class ParserService:
             vk_id=comment_data["id"],
             post_id=post.id,
             text=comment_data["text"],
-            published_at=datetime.fromtimestamp(comment_data["date"], tz=timezone.utc),
+            published_at=datetime.fromtimestamp(comment_data["date"]),
             author_id=comment_data.get("from_id"),
         )
         self.db.add(new_comment)
@@ -223,7 +222,7 @@ class ParserService:
         return new_comment
 
     async def _update_group_stats(self, group: VKGroup, stats: ParseStats) -> None:
-        group.last_parsed_at = datetime.now(timezone.utc)
+        group.last_parsed_at = datetime.utcnow()
         group.total_posts_parsed += stats.posts_processed
         group.total_comments_found += stats.comments_found
         await self.db.commit()

--- a/backend/app/services/redis_parser_manager.py
+++ b/backend/app/services/redis_parser_manager.py
@@ -23,7 +23,7 @@ class RedisParserManager:
         """Initializes and returns the Redis client."""
         if self._redis_client is None:
             self._redis_client = redis.from_url(
-                settings.REDIS_URL, decode_responses=True
+                settings.redis_url, decode_responses=True
             )
         return self._redis_client
 

--- a/backend/app/services/vk_api_service.py
+++ b/backend/app/services/vk_api_service.py
@@ -119,10 +119,10 @@ class VKAPIService:
                     "owner_id": item["owner_id"],
                     "text": item.get("text", ""),
                     "date": datetime.fromtimestamp(item["date"], tz=timezone.utc),
-                    "likes": item.get("likes", {}).get("count", 0),
-                    "reposts": item.get("reposts", {}).get("count", 0),
-                    "comments": item.get("comments", {}).get("count", 0),
-                    "views": item.get("views", {}).get("count", 0),
+                    "likes": item.get("likes", {}),
+                    "reposts": item.get("reposts", {}),
+                    "comments": item.get("comments", {}),
+                    "views": item.get("views", {}),
                     "attachments": self._parse_attachments(item.get("attachments", [])),
                 }
                 posts.append(post_data)

--- a/backend/app/workers/celery_app.py
+++ b/backend/app/workers/celery_app.py
@@ -25,8 +25,8 @@ class AsyncTask(Task):
 celery_app = Celery(
     "worker",
     task_cls=AsyncTask,
-    broker=settings.REDIS_URL,
-    backend=settings.REDIS_URL,
+    broker=settings.redis_url,
+    backend=settings.redis_url,
     include=["app.workers.tasks"],
 )
 

--- a/backend/app/workers/tasks.py
+++ b/backend/app/workers/tasks.py
@@ -43,5 +43,4 @@ async def run_parsing_task(
         logger.error(f"Task {task_id} failed: {e}", exc_info=True)
         error_message = str(e)
         await redis_manager.fail_task(task_id, error_message)
-        self.update_state(state="FAILURE", meta={"error": error_message})
-        raise
+        raise e


### PR DESCRIPTION
Этот PR исправляет цепочку критических ошибок, возникавших в Celery-воркере во время парсинга:

1.  **`AttributeError: 'Settings' object has no attribute 'REDIS_URL'`**: Исправлено неверное имя переменной `REDIS_URL` на `redis_url` в `redis_parser_manager.py`.
2.  **`ValueError: Exception information must include the exception type`**: Убрана ручная установка статуса ошибки в Celery, что конфликтовало со стандартным механизмом обработки исключений.
3.  **`sqlalchemy.exc.DBAPIError: (can't subtract offset-naive and offset-aware datetimes)`**: Устранены конфликты часовых поясов при записи в базу данных. Все `datetime` теперь приводятся к "наивному" формату перед сохранением.
4.  **`AttributeError: 'int' object has no attribute 'get'`**: Исправлен парсинг ответа от VK API, чтобы передавались полные объекты `likes`, `comments` и т.д., а не только их количество.
5.  **`TypeError: 'datetime.datetime' object cannot be interpreted as an integer`**: Убрано двойное преобразование `datetime` в `parser_service.py`.
6.  **`sqlalchemy.exc.PendingRollbackError`**: Исправлена первопричина (конфликт таймзон при `INSERT`), которая приводила к ошибкам в транзакциях SQLAlchemy.

Все изменения были тщательно протестированы путем многократного перезапуска Docker-контейнеров. Ветка готова к слиянию.