### PR TITLE
fix: добавлен safe.directory для git в деплой-скрипте (убирает ошибку dubious ownership)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -71,6 +71,9 @@ jobs:
             echo "Changing to app directory..."
             cd ${{ secrets.PRODUCTION_APP_DIR }}
 
+            echo "Configuring git safe.directory..."
+            git config --global --add safe.directory ${{ secrets.PRODUCTION_APP_DIR }}
+
             echo "Pulling latest changes from main branch..."
             git pull origin main
 


### PR DESCRIPTION
Добавил команду git config --global --add safe.directory ${{ secrets.PRODUCTION_APP_DIR }} в деплой-скрипт GitHub Actions для устранения ошибки 'detected dubious ownership in repository'.

Теперь деплой будет работать даже при разных владельцах каталога.

- Безопасность не нарушена, команда только для git.
- Можно мержить сразу после проверки.

P.S. Автоматизация — наше всё!