### PR TITLE
fix: добавлен build-контекст для backend в docker-compose.prod.ip.yml

### DIFF
--- a/docker-compose.prod.ip.yml
+++ b/docker-compose.prod.ip.yml
@@ -36,7 +36,10 @@ services:
 
   # FastAPI Backend
   backend:
-    image: ${DOCKER_IMAGE_BACKEND}
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    image: ${DOCKER_IMAGE_BACKEND:-fullstack-backend:latest}
     container_name: fullstack_backend_prod
     restart: always
     environment:


### PR DESCRIPTION
Добавлен build-контекст для backend в docker-compose.prod.ip.yml:
- Теперь backend можно собирать и запускать локально без переменных окружения
- Указан дефолтный image: fullstack-backend:latest
- Совместимо с CI/CD и ручной сборкой

После мержа можно пересобрать backend:
```
docker-compose -f docker-compose.prod.ip.yml build backend
docker-compose -f docker-compose.prod.ip.yml up -d backend
```

P.S. Теперь compose не будет ругаться, а backend будет собираться как надо!