### PR TITLE
fix(deploy): автоматическая зачистка старых контейнеров перед деплоем

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -85,6 +85,9 @@ jobs:
             echo "DOCKER_IMAGE_BACKEND=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_BACKEND }}:${{ needs.build.outputs.short_sha }}" >> .env.prod
             echo "DOCKER_IMAGE_FRONTEND=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_FRONTEND }}:${{ needs.build.outputs.short_sha }}" >> .env.prod
 
+            echo "Удаляем старые контейнеры, если остались..."
+            docker rm -f fullstack_postgres_prod fullstack_redis_prod fullstack_backend_prod fullstack_arq_worker_prod fullstack_frontend_prod || true
+
             echo "Pulling images and starting containers..."
             docker-compose -f docker-compose.prod.ip.yml pull
             docker-compose -f docker-compose.prod.ip.yml up -d --remove-orphans


### PR DESCRIPTION
- Добавлен шаг автоматического удаления старых контейнеров сервисов (postgres, redis, backend, arq_worker, frontend) перед запуском docker-compose up в deploy-production.yml
- Это предотвращает конфликты имён и падения деплоя из-за "container ... is already in use"
- Решение безопасно: все данные хранятся в volumes, контейнеры пересоздаются корректно

Проверьте деплой — теперь он должен проходить без ручного вмешательства даже при неудачных предыдущих попытках.

После мержа удалить ветку локально и на сервере!