### PR TITLE
fix(alembic): асинхронная строка подключения для Alembic (только asyncpg)

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -84,7 +84,7 @@ path_separator = os
 # database URL.  This is consumed by the user-maintained env.py script only.
 # other means of configuring database URLs may be customized within the env.py
 # file.
-sqlalchemy.url = postgresql://postgres:postgres@localhost:5432/vk_parser
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@localhost:5432/vk_parser
 
 
 [post_write_hooks]


### PR DESCRIPTION
- Исправлена строка подключения в alembic.ini: теперь используется postgresql+asyncpg, полностью асинхронный стек.
- psycopg2 больше не требуется, миграции работают только через asyncpg.

Проверьте деплой и миграции — теперь всё должно работать без sync-драйверов.

После мержа удалить ветку локально и на сервере!