### PR TITLE
fix(keywords): добавить прокрутку для таблицы ключевых слов и исправить импорты утилит в UI-компонентах

### DIFF
--- a/frontend/components/ui/avatar.tsx
+++ b/frontend/components/ui/avatar.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 function Avatar({
   className,

--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
   'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:pointer-events-none disabled:opacity-50',

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}

--- a/frontend/components/ui/label.tsx
+++ b/frontend/components/ui/label.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import * as LabelPrimitives from '@radix-ui/react-label'
 import { cva, type VariantProps } from 'class-variance-authority'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const labelVariants = cva(
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'

--- a/frontend/components/ui/progress.tsx
+++ b/frontend/components/ui/progress.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import * as ProgressPrimitive from '@radix-ui/react-progress'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,

--- a/frontend/components/ui/select.tsx
+++ b/frontend/components/ui/select.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import * as SelectPrimitive from '@radix-ui/react-select'
 import { Check, ChevronDown } from 'lucide-react'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const Select = SelectPrimitive.Root
 

--- a/frontend/components/ui/switch.tsx
+++ b/frontend/components/ui/switch.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import * as SwitchPrimitives from '@radix-ui/react-switch'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,

--- a/frontend/components/ui/table.tsx
+++ b/frontend/components/ui/table.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (

--- a/frontend/features/keywords/ui/KeywordsPage.test.tsx
+++ b/frontend/features/keywords/ui/KeywordsPage.test.tsx
@@ -5,7 +5,7 @@ import {
   waitFor,
   within,
 } from '@testing-library/react'
-import KeywordsPage from '../page'
+import KeywordsPage from './KeywordsPage'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Toaster } from 'react-hot-toast'
 import type { KeywordResponse } from '@/types/api'

--- a/frontend/features/keywords/ui/KeywordsPage.tsx
+++ b/frontend/features/keywords/ui/KeywordsPage.tsx
@@ -185,29 +185,32 @@ export default function KeywordsPage() {
       )
     }
 
+    // Добавляем скроллируемый контейнер для таблицы
     return (
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Ключевое слово</TableHead>
-            <TableHead>Найдено комментариев</TableHead>
-            <TableHead>Статус</TableHead>
-            <TableHead className="text-right">Действия</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {filteredKeywords.map((keyword) => (
-            <KeywordRow
-              key={keyword.id}
-              keyword={keyword}
-              onUpdate={handleUpdateKeyword}
-              onDelete={handleDeleteKeyword}
-              isUpdating={updateKeywordMutation.isPending}
-              isDeleting={deleteKeywordMutation.isPending}
-            />
-          ))}
-        </TableBody>
-      </Table>
+      <div className="max-h-[400px] overflow-y-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Ключевое слово</TableHead>
+              <TableHead>Найдено комментариев</TableHead>
+              <TableHead>Статус</TableHead>
+              <TableHead className="text-right">Действия</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredKeywords.map((keyword) => (
+              <KeywordRow
+                key={keyword.id}
+                keyword={keyword}
+                onUpdate={handleUpdateKeyword}
+                onDelete={handleDeleteKeyword}
+                isUpdating={updateKeywordMutation.isPending}
+                isDeleting={deleteKeywordMutation.isPending}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     )
   }
 


### PR DESCRIPTION
### Что сделано:
- Добавлена вертикальная прокрутка для таблицы ключевых слов на странице KeywordsPage (max-h-[400px] overflow-y-auto).
- Исправлены все импорты утилиты cn во всех UI-компонентах с '@/shared/lib/utils' на '@/lib/utils' для корректной работы приложения и тестов.
- Обновлён импорт KeywordsPage в тестах.

### Как проверить:
1. Откройте страницу ключевых слов — при большом количестве слов появляется скролл, новые слова всегда видны.
2. Проверьте, что UI-компоненты работают корректно, ошибки импорта отсутствуют.
3. При необходимости — обновите/дополните тесты под новую структуру.

---

Если потребуется — готов доработать тесты или стили по пожеланиям.