### PR TITLE
fix(ci): добавить contents: read для security job (GitHub Actions)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -36,6 +36,7 @@ jobs:
   security:
     name: Security Scan
     permissions:
+      contents: read
       actions: read
       security-events: write
     uses: ./.github/workflows/security.yml


### PR DESCRIPTION
Добавлены права contents: read для security job в deploy-production.yml, чтобы вложенные reusable job-ы (trufflehog, docker-security-scan) могли корректно читать содержимое репозитория и запускаться без ошибок permissions. 

- Исправляет ошибку: "The nested job 'trufflehog' is requesting 'contents: read', but is only allowed 'contents: none'"
- После мержа ветка будет удалена автоматически.

Инструкция для тестирования:
1. Дождаться успешного прогона пайплайна после merge.
2. Проверить, что security-джоба проходит без ошибок permissions.

Связанные задачи: исправление CI/CD, права для reusable workflows.