### PR TITLE
fix(frontend): заменить импорты cn на '@/lib/utils' во всех компонентах

### DIFF
--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -3,7 +3,7 @@
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
 import { Bell, ChevronRight } from 'lucide-react'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -10,7 +10,7 @@ import {
   Play,
   Settings,
 } from 'lucide-react'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const navigation = [
   { name: 'Дашборд', href: '/dashboard', icon: BarChart3 },

--- a/frontend/components/ui/loading-spinner.tsx
+++ b/frontend/components/ui/loading-spinner.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 interface LoadingSpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: 'sm' | 'md' | 'lg'

--- a/frontend/shared/ui/avatar.tsx
+++ b/frontend/shared/ui/avatar.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 function Avatar({
   className,

--- a/frontend/shared/ui/badge.tsx
+++ b/frontend/shared/ui/badge.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
   // Строгая рамка, минимум скруглений, строгие цвета

--- a/frontend/shared/ui/button.tsx
+++ b/frontend/shared/ui/button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
   // Строгие рамки, прямоугольная форма, минимум скруглений

--- a/frontend/shared/ui/card.tsx
+++ b/frontend/shared/ui/card.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/frontend/shared/ui/input.tsx
+++ b/frontend/shared/ui/input.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}

--- a/frontend/shared/ui/label.tsx
+++ b/frontend/shared/ui/label.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import * as LabelPrimitives from '@radix-ui/react-label'
 import { cva, type VariantProps } from 'class-variance-authority'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const labelVariants = cva(
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'

--- a/frontend/shared/ui/loading-spinner.tsx
+++ b/frontend/shared/ui/loading-spinner.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 interface LoadingSpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: 'sm' | 'md' | 'lg'

--- a/frontend/shared/ui/progress.tsx
+++ b/frontend/shared/ui/progress.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import * as ProgressPrimitive from '@radix-ui/react-progress'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,

--- a/frontend/shared/ui/select.tsx
+++ b/frontend/shared/ui/select.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import * as SelectPrimitive from '@radix-ui/react-select'
 import { Check, ChevronDown } from 'lucide-react'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const Select = SelectPrimitive.Root
 

--- a/frontend/shared/ui/switch.tsx
+++ b/frontend/shared/ui/switch.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import * as SwitchPrimitives from '@radix-ui/react-switch'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,

--- a/frontend/shared/ui/table.tsx
+++ b/frontend/shared/ui/table.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 
-import { cn } from '@/shared/lib/utils'
+import { cn } from '@/lib/utils'
 
 const Table = React.forwardRef<
   HTMLTableElement,


### PR DESCRIPTION
- Исправлены все импорты cn: теперь используется '@/lib/utils' вместо '@/shared/lib/utils'.
- Это устраняет ошибку Module not found: Can't resolve '@/shared/lib/utils' при сборке фронта.

Инструкция для тестирования:
1. Дождаться успешного прогона фронтового билда в CI.
2. Убедиться, что ошибка с импортом cn больше не возникает.

После merge ветка будет удалена автоматически.