### PR TITLE
fix(tests): добавить VK_ACCESS_TOKEN для тестов (устранение ошибки VKSettings)

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -3,7 +3,8 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = 
+addopts = -ra -q
+env = VK_ACCESS_TOKEN=dummy_token_for_tests
     -v
     --strict-markers
     --disable-warnings


### PR DESCRIPTION
- Добавлен VK_ACCESS_TOKEN в pytest.ini для тестовой среды.
- Теперь VKSettings инициализируется без ошибок, тесты запускаются корректно.

Инструкция для тестирования:
1. Запустить тесты backend — ошибка VK_ACCESS_TOKEN исчезнет.
2. Убедиться, что все тесты проходят или видны реальные ошибки тестов.

После merge ветка будет удалена автоматически.