### PR TITLE
fix(pytest): включить importlib-режим и testpaths для стабильного поиска тестов на CI/CD

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
-addopts = --maxfail=5 --disable-warnings -v
+addopts = --import-mode=importlib
+# Максимум 5 ошибок, отключить ворнинги, подробный вывод
+# addopts = --maxfail=5 --disable-warnings -v --import-mode=importlib
+testpaths = tests
 env = VK_ACCESS_TOKEN=fake_token_for_tests
     -v
     --strict-markers


### PR DESCRIPTION
- Удалён __init__.py из backend/tests (если был)
- В pytest.ini добавлен importlib-режим и testpaths=tests
- Теперь pytest стабильно находит тесты и локально, и на CI/CD

Инструкции для тестирования:
1. poetry install
2. poetry run pytest

После мержа удалить ветку локально и на сервере.