### PR TITLE
fix(ci): PYTHONPATH указывает на backend для корректного поиска пакета app в тестах CI/CD

### DIFF
--- a/.github/workflows/reusable-backend-test.yml
+++ b/.github/workflows/reusable-backend-test.yml
@@ -163,14 +163,14 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Run tests
-        working-directory: ./backend
+        working-directory: backend
         env:
           DATABASE_URL: postgresql+asyncpg://test_user:test_password@localhost:5432/test_db
           REDIS_URL: redis://localhost:6379
-          PYTHONPATH: ./app
+          PYTHONPATH: ${{ github.workspace }}/backend
         run: |
           source .venv/bin/activate
-          pytest --cov=app --cov-report=xml --cov-fail-under=0
+          poetry run pytest --cov=app --cov-report=xml --cov-fail-under=0
 
       - name: Upload coverage artifact
         if: inputs.upload-coverage == '"true"' && matrix.python-version == env.PYTHON_VERSION_DEFAULT


### PR DESCRIPTION
- В .github/workflows/reusable-backend-test.yml переменная PYTHONPATH теперь указывает на backend.
- Это гарантирует, что импорты вида from app... работают в тестах CI/CD, как и локально.
- Исправляет ошибку ModuleNotFoundError: No module named 'app' при запуске тестов в GitHub Actions.

Инструкция для тестирования:
1. Запусти пайплайн CI/CD — тесты должны запускаться и проходить.
2. Локально ничего менять не нужно, всё работает как прежде.

После мержа удалить ветку локально и на сервере.