### PR TITLE
fix(api): реализован агрегирующий роутер api_router для API v1 по образцу api.py

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,3 +1,36 @@
 """
-Агрегирующий роутер для API v1
+Агрегирующий роутер для API v1 (экспортируется как api_router)
 """
+
+from fastapi import APIRouter
+from app.api.v1 import comments, groups, health, keywords, parser, stats
+
+api_router = APIRouter()
+
+api_router.include_router(health.router, prefix="/health", tags=["Health"])
+api_router.include_router(
+    comments.router, prefix="/comments", tags=["Comments"]
+)
+api_router.include_router(groups.router, prefix="/groups", tags=["Groups"])
+api_router.include_router(
+    keywords.router, prefix="/keywords", tags=["Keywords"]
+)
+api_router.include_router(parser.router, prefix="/parser", tags=["Parser"])
+api_router.include_router(stats.router, prefix="/stats", tags=["Stats"])
+
+
+@api_router.get("/", tags=["Info"])
+async def api_info() -> dict[str, str | dict[str, str]]:
+    """Информация об API v1"""
+    return {
+        "service": "VK Comments Parser API",
+        "version": "1.0.0",
+        "endpoints": {
+            "comments": "/comments - Найденные комментарии",
+            "groups": "/groups - Управление VK группами",
+            "keywords": "/keywords - Управление ключевыми словами",
+            "parser": "/parser - Парсинг и поиск комментариев",
+            "stats": "/stats - Статистика системы",
+            "health": "/health - Состояние сервиса",
+        },
+    }


### PR DESCRIPTION
- В backend/app/api/v1/router.py реализован агрегирующий роутер api_router.
- Подключены все подроутеры (health, comments, groups, keywords, parser, stats) с префиксами и тегами.
- Добавлен endpoint / (api_info) с описанием API v1.
- Теперь структура роутеров соответствует best practices FastAPI и примеру из api.py.

Инструкция для тестирования:
1. Убедись, что импортируется api_router из app.api.v1.router.
2. Проверь, что все эндпоинты работают и отображаются в OpenAPI.
3. Запусти тесты — ошибка импорта исчезнет.

После мержа удалить ветку локально и на сервере.