### PR TITLE
fix(backend): исправить права доступа в entrypoint.sh

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Применяем миграции Alembic
-poetry run alembic upgrade head
+alembic upgrade head
 
 # Запускаем FastAPI
-exec poetry run uvicorn app.main:app --host 0.0.0.0 --port 8000
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Описание

Исправлена проблема с правами доступа в backend контейнере, которая приводила к бесконечным рестартам.

## Проблема

Backend контейнер не мог стартовать из-за ошибки:


## Решение

- Убрал  из команд в entrypoint.sh
- Зависимости уже установлены глобально через uv в Dockerfile
- Теперь alembic и uvicorn вызываются напрямую

## Изменения

- : убрал poetry run из команд

## Тестирование

После merge нужно пересобрать backend образ и протестировать деплой.

## Связанные issues

Fixes #backend-container-permissions-issue