### PR TITLE
fix(ci): исправить права доступа в GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       upload-coverage: '"true"'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    permissions:
+      contents: write
 
   frontend:
     uses: ./.github/workflows/reusable-frontend-test.yml


### PR DESCRIPTION
## Описание

Исправлена ошибка с правами доступа в GitHub Actions workflow.

## Проблема

Job  в reusable workflow запрашивал права  для автоформатирования кода, но основной workflow  предоставлял только права .

Ошибка:


## Решение

Добавлены права  для backend job в основном workflow :



## Изменения

- ✅ Добавлены  для backend job
- ✅ Сохранена функциональность автоформатирования кода
- ✅ Протестирован YAML синтаксис

## Тестирование

- [x] Проверен YAML синтаксис
- [x] Прошли pre-commit хуки
- [x] Создан коммит с Conventional Commits

## Связанные issues

Исправляет ошибку в GitHub Actions CI/CD pipeline.