### PR TITLE
fix(ci,cd): деплой только после успешного CI, тесты и security только в CI, обновлён pyproject.toml, автоформатирование и мелкие правки

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir -r requirements-build.txt && poetry config virtua
 COPY pyproject.toml poetry.lock* ./
 
 # Устанавливаем зависимости напрямую через poetry
-RUN poetry install --no-dev --no-root
+RUN poetry install --only=main --no-root
 
 # Копируем только нужные директории (исключая тесты, .git и т.д.)
 COPY app/ ./app/


### PR DESCRIPTION
- Деплой теперь только после успешного CI (workflow_run)
- Все тесты и security проверки только в CI
- deploy-production.yml не содержит тестов, только build и deploy
- pyproject.toml переведён на современный формат
- Автоформатирование и мелкие правки по всему проекту

Проверить:
- CI должен проходить полностью
- Деплой должен запускаться только после успешного CI
- Нет лишних тестов в деплое

После мержа удалить ветку локально и на сервере!