### PR TITLE
fix(deploy): агрессивная очистка Docker кэша для стабильного деплоя

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -118,9 +118,15 @@ jobs:
             echo "🔐 Логин в GitHub Container Registry..."
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
-            echo "🧹 Очистка старых образов..."
-            docker image prune -f || true
-            docker system prune -f || true
+            echo "🧹 Очистка Docker кэша перед деплоем..."
+            if [ -f "scripts/docker-cleanup.sh" ]; then
+              chmod +x scripts/docker-cleanup.sh
+              ./scripts/docker-cleanup.sh --aggressive
+            else
+              echo "⚠️ Скрипт очистки не найден, используем стандартную очистку"
+              docker image prune -f || true
+              docker system prune -f || true
+            fi
 
             echo "📦 Загрузка Docker образов..."
             docker-compose -f docker-compose.prod.ip.yml pull
@@ -128,8 +134,12 @@ jobs:
             echo "🚀 Запуск сервисов..."
             docker-compose -f docker-compose.prod.ip.yml up -d --build
 
-            echo "🧹 Очистка неиспользуемых образов после деплоя..."
-            docker image prune -f || true
+            echo "🧹 Очистка Docker кэша после деплоя..."
+            if [ -f "scripts/docker-cleanup.sh" ]; then
+              ./scripts/docker-cleanup.sh
+            else
+              docker image prune -f || true
+            fi
 
             echo "✅ Деплой завершен успешно!"
 


### PR DESCRIPTION
### Что сделано
- Добавлена агрессивная очистка Docker-кэша перед деплоем и обычная после деплоя в workflow GitHub Actions.
- Используется скрипт scripts/docker-cleanup.sh, если он есть, иначе fallback на стандартную очистку.
- Настроен cron для автоматической ежедневной очистки Docker-кэша на сервере.
- Решает проблему "The operation was canceled" при деплое из-за переполнения Docker.

### Инструкция для тестирования
1. Запустить деплой через Actions вручную или дождаться CI.
2. Убедиться, что очистка кэша проходит успешно (см. логи Actions и /var/log/docker-cleanup.log на сервере).
3. Проверить, что деплой завершается без ошибок, сервисы стартуют корректно.

---
Если что — Docker теперь чистый, как совесть младшего лейтенанта после первого дежурства!