### PR TITLE
fix: правильное кэширование pnpm в setup-node для CI/CD

### DIFF
--- a/.github/workflows/advanced-ci.yml
+++ b/.github/workflows/advanced-ci.yml
@@ -36,8 +36,9 @@ jobs:
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: 🟢 TypeScript линтинг
         working-directory: ./frontend
@@ -60,8 +61,9 @@ jobs:
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: 🐍 Backend тесты
         working-directory: ./backend


### PR DESCRIPTION
## Что сделано\n\n- Указан cache: 'pnpm' и cache-dependency-path: frontend/pnpm-lock.yaml для jobs lint и test\n- Теперь actions/setup-node не будет ругаться на отсутствие lock-файла и будет кэшировать зависимости pnpm корректно\n\n## Тип изменений\n- [x] Bug fix (исправление ошибки)\n- [ ] New feature (новая функция)\n- [ ] Breaking change (критическое изменение)\n- [ ] Documentation (документация)