### PR TITLE
fix: убрано кэширование pnpm из setup-node, чтобы не было ошибки запуска pnpm

### DIFF
--- a/.github/workflows/advanced-ci.yml
+++ b/.github/workflows/advanced-ci.yml
@@ -37,8 +37,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: 🟢 TypeScript линтинг
         working-directory: ./frontend
@@ -62,8 +60,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: 🐍 Backend тесты
         working-directory: ./backend


### PR DESCRIPTION
## Что сделано

- Убрано кэширование pnpm из setup-node (actions/setup-node@v4)
- Теперь setup-node просто ставит Node.js, а pnpm ставится отдельным шагом
- Исправлена ошибка: Unable to locate executable file: pnpm

## Тип изменений

- [x] Bug fix
- [ ] Feature
- [ ] Chore
- [ ] Documentation
