### PR TITLE
chore: ускорен деплой — docker compose up --build --pull always вместо отдельного pull

### DIFF
--- a/.github/workflows/advanced-ci.yml
+++ b/.github/workflows/advanced-ci.yml
@@ -179,11 +179,8 @@ jobs:
           set -e
           cd ${{ secrets.PRODUCTION_APP_DIR }}
 
-          echo "📦 Загрузка образов..."
-          docker compose -f docker-compose.prod.ip.yml pull
-
           echo "🚀 Запуск сервисов..."
-          docker compose -f docker-compose.prod.ip.yml up -d --build
+          docker compose -f docker-compose.prod.ip.yml up -d --build --pull always
 
           echo "🧹 Очистка..."
           docker image prune -f || true


### PR DESCRIPTION
## Что сделано

- Оптимизирован деплой: теперь docker compose up -d --build --pull always
- Убран отдельный pull, теперь образы скачиваются только если есть новые
- Деплой стал быстрее и надёжнее

## Тип изменений
- [x] Chore (техническое обслуживание)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
