### PR TITLE
fix: отключён зависающий pnpm cache во всех jobs

### DIFF
--- a/.github/workflows/advanced-ci.yml
+++ b/.github/workflows/advanced-ci.yml
@@ -33,7 +33,7 @@ jobs:
           poetry run black --check .
           poetry run isort --check-only .
 
-      - name: 🟢 Setup Node.js, pnpm and cache
+      - name: 🟢 Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -56,7 +56,7 @@ jobs:
       - name: ⬇️ Checkout code
         uses: actions/checkout@v4
 
-      - name: 🟢 Setup Node.js, pnpm and cache
+      - name: 🟢 Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -95,12 +95,10 @@ jobs:
       - name: ⬇️ Checkout code
         uses: actions/checkout@v4
 
-      - name: 🟢 Setup Node.js, pnpm and cache
+      - name: 🟢 Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: 🐍 Python security (bandit)
         working-directory: ./backend


### PR DESCRIPTION
## Что сделано

- Отключён зависающий pnpm cache во всех jobs
- Убраны cache и cache-dependency-path из setup-node
- Теперь CI/CD не будет зависать на создании кэша 286сё работает быстро и стабильно

## Тип изменений

- [x] Bug fix
- [ ] Feature
- [ ] Chore
