### PR TITLE
fix: убрать предупреждение SSH о псевдо-терминале

### DIFF
--- a/.github/workflows/advanced-ci.yml
+++ b/.github/workflows/advanced-ci.yml
@@ -293,7 +293,7 @@ jobs:
         run: |
           set -e
           echo "🚀 Подключение к серверу..."
-          ssh -o StrictHostKeyChecking=no ${{ secrets.PRODUCTION_USER }}@${{ secrets.PRODUCTION_HOST }} <<EOF
+          ssh -T -o StrictHostKeyChecking=no ${{ secrets.PRODUCTION_USER }}@${{ secrets.PRODUCTION_HOST }} <<EOF
           cd ${{ secrets.PRODUCTION_APP_DIR }}
           echo "🚀 Запуск сервисов..."
           docker compose -f docker-compose.prod.ip.yml up -d --build --pull always


### PR DESCRIPTION
Добавлен флаг -T к SSH команде для отключения выделения псевдо-терминала в CI/CD среде