### PR TITLE
fix(ci): исправлена синтаксическая ошибка в регулярных выражениях версионирования

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -43,7 +43,7 @@ jobs:
             MINOR_BUMP=false
             PATCH_BUMP=false
             while IFS= read -r commit; do
-              if [[ $commit =~ ^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\(.+\))?!: ]] || [[ $commit =~ BREAKING[ ]CHANGE ]]; then
+              if [[ $commit =~ ^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\(.+\))?\!: ]] || [[ $commit =~ BREAKING[[:space:]]CHANGE ]]; then
                 MAJOR_BUMP=true
                 echo "Found breaking change in commit: $commit"
               elif [[ $commit =~ ^feat(\(.+\))?: ]]; then


### PR DESCRIPTION
## Описание

Исправлена синтаксическая ошибка в скрипте семантического версионирования, которая приводила к падению CI/CD процесса с кодом 2.

## Изменения

- Экранирован восклицательный знак в регулярном выражении для breaking changes: `\!` вместо `!`
- Заменен `[ ]` на `[[:space:]]` для корректного поиска пробелов в bash
- Исправлена ошибка "синтаксическая ошибка в условном выражении" в строке 16

## Тестирование

Протестировано локально - регулярные выражения теперь корректно обрабатывают:
- `feat!: breaking change` 
- `BREAKING CHANGE: something`

## Тип изменений

- [x] Bug fix (исправление ошибки)
- [ ] New feature (новая функция)
- [ ] Breaking change (критическое изменение)
- [ ] Documentation update (обновление документации)