### PR TITLE
fix(ci): исправлена синтаксическая ошибка в sed команде версионирования

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -68,8 +68,8 @@ jobs:
               echo "Bump type: NONE (no conventional commits found)"
             fi
             if [ "$BUMP_TYPE" != "none" ]; then
-              VERSION_PARTS=$(echo $CURRENT_VERSION | sed 's/v//' | tr '.' ' ')
-              read MAJOR MINOR PATCH <<< $VERSION_PARTS
+              VERSION_PARTS=$(echo $CURRENT_VERSION | sed "s/v//" | tr '.' ' ')
+              read MAJOR MINOR PATCH <<< "$VERSION_PARTS"
               case $BUMP_TYPE in
                 major)
                   NEW_MAJOR=$((MAJOR + 1))


### PR DESCRIPTION
Исправлена синтаксическая ошибка в bash скрипте версионирования. Проблема была в использовании одинарных кавычек внутри одинарных кавычек в sed команде. Заменено на двойные кавычки для корректной работы.